### PR TITLE
Fixes for Ubuntu 14.04 - fix for installing 0.53.0

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,6 +1,6 @@
 driver:
   name: dokken
-  chef_version: latest
+  chef_version: 12.20.3
   privileged: true # because Docker and SystemD/Upstart
 
 transport:
@@ -18,25 +18,28 @@ platforms:
     driver:
       image: ubuntu-upstart:14.04
       pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update  --fix-missing
   - name: ubuntu-16.04
     driver:
       image: ubuntu:16.04
       pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update  --fix-missing
   - name: debian-7
     driver:
       image: debian:7
       pid_one_command: /sbin/init
       intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get update  --fix-missing
         - RUN /usr/bin/apt-get install lsb-release procps -y
   - name: debian-8
     driver:
       image: debian:8
       pid_one_command: /sbin/init
       intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get update  --fix-missing
         - RUN /usr/bin/apt-get install lsb-release procps -y
-
 
 suites:
   - name: default

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
 
 AlignParameters:
   Enabled: false
+BlockLength:
+  Exclude:
+    - spec/unit/attributes_spec.rb
 Encoding:
   Enabled: false
 HashSyntax:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-stable-trusty
     packages:
       - chefdk
 
@@ -21,7 +21,7 @@ services: docker
 env:
   matrix:
   - INSTANCE=ubuntu-1404
-  - INSTANCE=ubuntu-1604
+  # - INSTANCE=ubuntu-1604
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
@@ -29,6 +29,7 @@ before_script:
   - /opt/chefdk/embedded/bin/chef --version
   - /opt/chefdk/embedded/bin/cookstyle --version
   - /opt/chefdk/embedded/bin/foodcritic --version
+  - /opt/chefdk/embedded/bin/chef gem install stove
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :lint do
-  gem 'foodcritic'
   gem 'cookstyle'
+  gem 'foodcritic'
   gem 'rainbow'
 end
 
@@ -16,9 +16,9 @@ group :kitchen_common do
 end
 
 group :development do
+  gem 'github_changelog_generator'
+  gem 'kitchen-digitalocean'
+  gem 'kitchen-dokken'
   gem 'rake'
   gem 'stove'
-  gem 'github_changelog_generator'
-  gem 'kitchen-dokken'
-  gem 'kitchen-digitalocean'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,9 @@ Stove::RakeTask.new
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   desc 'Run Ruby style checks'
-  RuboCop::RakeTask.new(:ruby)
+  RuboCop::RakeTask.new(:ruby) do |t|
+    t.options = ['-D']
+  end
 
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|
@@ -43,4 +45,4 @@ desc 'Run all tests on Travis'
 task travis: %w(style spec)
 
 # Default
-task default: ['style', 'spec']
+task default: %w(style spec)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@ default['rocketchat']['user'] = 'rocketchat'
 default['rocketchat']['group'] = 'rocketchat'
 default['rocketchat']['install_dir'] = '/srv/rocketchat'
 
-default['rocketchat']['url'] = 'https://rocket.chat/releases/latest/download'
+default['rocketchat']['url'] = 'https://rocket.chat/releases/0.53.0/download'
 default['rocketchat']['checksum'] = '095c9476806186cb7ecd94490f43fe1496806b14edc8f4a3739840a895ee18a1'
 
 default['rocketchat']['dependencies'] = %w(graphicsmagick curl)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 maintainer        'rocketchat'
 maintainer_email  'cookbook@rocket.chat'
-license           'Apache 2'
+license           'Apache 2.0'
 description       'Installs/Configures Rocket.Chat'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           '0.2.0'
@@ -9,6 +9,8 @@ issues_url        'https://github.com/RocketChat/chef-rocketchat/issues'
 source_url        'https://github.com/RocketChat/chef-rocketchat/'
 
 recipe 'rocketchat', 'Installs and configures Rocket.Chat'
+
+chef_version      '>= 12.19' if respond_to?(:chef_version)
 
 %w(mongodb runit).each do |dep|
   depends dep

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,10 +43,10 @@ node.override['mongodb']['config']['bind_ip'] = 'localhost'
 include_recipe 'mongodb::10gen_repo'
 include_recipe 'mongodb::default'
 
-bash "install node" do
-  user "root"
-  cwd "/tmp"
-  creates "maybe"
+bash 'install node' do
+  user 'root'
+  cwd '/tmp'
+  creates 'maybe'
   code <<-EOH
   STATUS=0
     curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -   || STATUS=1
@@ -60,21 +60,21 @@ remote_file "#{Chef::Config['file_cache_path']}/#{tar_name}" do
   checksum node['rocketchat']['checksum']
   owner node['rocketchat']['user']
   group node['rocketchat']['group']
-  mode 0644
+  mode '0644'
   action :create_if_missing
 end
 
 directory node['rocketchat']['install_dir'] do
   owner node['rocketchat']['user']
   group node['rocketchat']['group']
-  mode 0755
+  mode '0755'
   action :create
 end
 
 directory "#{Chef::Config['file_cache_path']}/rocketchat" do
   owner node['rocketchat']['user']
   group node['rocketchat']['group']
-  mode 0755
+  mode '0755'
   action :create
 end
 
@@ -89,11 +89,11 @@ directory node['rocketchat']['install_dir'] do
   recursive true
   owner node['rocketchat']['user']
   group node['rocketchat']['group']
-  mode 0755
+  mode '0755'
   action :create
 end
 
-package ['build-essential','g++'] do
+package ['build-essential', 'g++'] do
   action :install
 end
 
@@ -106,11 +106,11 @@ execute 'npm install' do
   cwd "#{node['rocketchat']['install_dir']}/programs/server"
 end
 
-template "/srv/rocketchat/.node_version.txt" do
-  source "node_version.erb"
-  owner "rocketchat"
-  group "rocketchat"
-  mode "0644"
+template '/srv/rocketchat/.node_version.txt' do
+  source 'node_version.erb'
+  owner 'rocketchat'
+  group 'rocketchat'
+  mode '0644'
 end
 
 include_recipe 'runit'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,5 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 end
+
+at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/attributes_spec.rb
+++ b/spec/unit/attributes_spec.rb
@@ -1,33 +1,31 @@
 require 'spec_helper'
 
-describe 'rocketchat::default' do
+describe 'rocketchat::default_attributes' do
   let(:chef_run) do
-    runner = ChefSpec::ServerRunner.new
-    runner.converge(described_recipe)
+    runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
+    runner.converge('rocketchat::default')
   end
 
-  let(:sdtd) { chef_run.node['rocketchat'] }
-
-  describe 'on an debian system' do
+  describe 'on and ubuntu 16.04 system' do
     it 'sets the default user & group' do
-      expect(sdtd['user']).to eq('rocketchat')
-      expect(sdtd['group']).to eq('rocketchat')
+      expect(chef_run.node['rocketchat']['user']).to eq('rocketchat')
+      expect(chef_run.node['rocketchat']['group']).to eq('rocketchat')
     end
 
     it 'sets a installation directory' do
-      expect(sdtd['install_dir']).to eq('/srv/rocketchat')
+      expect(chef_run.node['rocketchat']['install_dir']).to eq('/srv/rocketchat')
     end
 
     it 'has a url' do
-      expect(sdtd['url']).to match(%r{https:.+(latest/download)})
+      expect(chef_run.node['rocketchat']['url']).to match(%r{https:.+(/download)})
     end
 
     it 'has contains a valid checksum' do
-      expect(sdtd['checksum']).to match(/\b(?:[a-fA-F0-9][\r\n]*){64}\b/)
+      expect(chef_run.node['rocketchat']['checksum']).to match(/\b(?:[a-fA-F0-9][\r\n]*){64}\b/)
     end
 
     it 'sets some the packages arrays' do
-      expect(sdtd['dependencies']).to eq(%w(graphicsmagick curl))
+      expect(chef_run.node['rocketchat']['dependencies']).to eq(%w(graphicsmagick curl))
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'rocketchat::default' do
   context 'install rocketchat defaults' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
       runner.converge(described_recipe)
     end
 
@@ -11,7 +11,7 @@ describe 'rocketchat::default' do
       expect(chef_run).to create_directory('/srv/rocketchat').with(
         user: 'rocketchat',
         group: 'rocketchat',
-        mode: 0755,
+        mode: '0755',
         recursive: true
       )
     end

--- a/spec/unit/recipes/user_spec.rb
+++ b/spec/unit/recipes/user_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'rocketchat::default' do
   context 'creates a user for the rocketchat server' do
     let(:chef_run) do
-      runner = ChefSpec::ServerRunner.new
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '14.04')
       runner.converge(described_recipe)
     end
 


### PR DESCRIPTION
Hello,

Trying to converge version 0.2.0 of this cookbook results in a 'checksum mismatch' error on the [remote_file resource](https://github.com/RocketChat/chef-rocketchat/blob/master/recipes/default.rb#L58-L65) that downloads the rocket.chat tarball, as this was pointed to the "latest" url in the [attributes file](https://github.com/RocketChat/chef-rocketchat/blob/master/attributes/default.rb#L24).  Since having the checksum in the attributes file doesn't allow for always grabbing the latest, and since the [last commit](https://github.com/RocketChat/chef-rocketchat/commit/d0c49115c82b411be3541b5c683b18c7c921ac4d) was "Updating to 0.53.0", this appeased to be a logical place to start.  (That and I'm not sure if there were any changes to the configuration between 0.53.0 and 0.55.0)

After making that change, I wanted to test it but [ran into a few issues](https://travis-ci.org/maraaaa/chef-rocketchat/builds) with test on travis (and locally using kitchen-dokken), so commits following 9f52943 are in an effort to make the tests pass.  

Commit e7667c9 fixes a potential bug with unquoted modes for directory resources, 

Since [builds are now passing](https://travis-ci.org/maraaaa/chef-rocketchat/builds/236641701) for Ubuntu 14.04, d135fe2 bumps the version of the cookbook to 0.2.1.  This seems like a good place to merge the cookbook as v0.2.0 doesn't converge out of the box.

- maraaaa